### PR TITLE
Require Go 1.7+ in Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: go
 go:
-  - 1.1
-  - 1.2
+  - 1.7
   - tip


### PR DESCRIPTION
Drop support for Go 1.6 and earlier, because we now use vendored dependencies (Go 1.5/1.6+) and subtests (Go 1.7+).


Once this is merged, I'll rebase https://github.com/stripe/unilog/pull/1 onto master before merging that one; I'm doing this as two separate PRs to keep a clean CI timeline.


r? @nelhage 
cc @kiran @gphat @tummychow 