### PR TITLE
Support multiple filter functions

### DIFF
--- a/unilog_test.go
+++ b/unilog_test.go
@@ -51,13 +51,23 @@ func TestReadlinesWithLongLines(t *testing.T) {
 
 func TestFilterFunction(t *testing.T) {
 	var input = shakespeare[0]
-	const expected = "To bee, or not to bee, that is the question-\n"
+	const expected = "To bee, or not to bee, that ain't the question-\n"
 
 	u := &Unilog{}
-	var sampleFilter = func(s string) string {
+
+	// double the first two instances of the character "e"
+	var doubleEFilter = func(s string) string {
 		return strings.Replace(s, "e", "ee", 2)
 	}
-	u.Filter = sampleFilter
+
+	var isToAintFilter = func(s string) string {
+		return strings.Replace(s, "is", "ain't", -1)
+	}
+
+	u.Filters = []Filter{
+		Filter(doubleEFilter),
+		Filter(isToAintFilter),
+	}
 
 	result := u.format(input)
 
@@ -72,5 +82,4 @@ func TestFilterFunction(t *testing.T) {
 	if result != expected {
 		t.Errorf("expected %q, found %q", expected, result)
 	}
-
 }

--- a/unilog_test.go
+++ b/unilog_test.go
@@ -48,3 +48,29 @@ func TestReadlinesWithLongLines(t *testing.T) {
 		t.Error("Did not reach EOF")
 	}
 }
+
+func TestFilterFunction(t *testing.T) {
+	var input = shakespeare[0]
+	const expected = "To bee, or not to bee, that is the question-\n"
+
+	u := &Unilog{}
+	var sampleFilter = func(s string) string {
+		return strings.Replace(s, "e", "ee", 2)
+	}
+	u.Filter = sampleFilter
+
+	result := u.format(input)
+
+	i := strings.Index(result, "]")
+	if i == -1 {
+		t.Errorf("Expected timestamp but found none")
+	}
+
+	// Remove the entire timestamp and the leading space to avoid
+	// having to match the timestamp part of the string in the test
+	result = result[i+2:]
+	if result != expected {
+		t.Errorf("expected %q, found %q", expected, result)
+	}
+
+}


### PR DESCRIPTION
Add support for mutliple filter functions, rather than just one. This will be helpful for the Splunk QoS work that @kiran and I are doing.

Technically we can get this functionality without any Unilog changes by passing `h(x) = f(g(x))` as the filter function, but it's cleaner to be explicit.


r? @kiran-stripe || @nelhage-stripe 

