### PR TITLE
Copy Observability on all pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+Please follow this checklist and fill in the template below before assigning a reviewer: https://hackpad.corp.stripe.com/Code-reviews-HtMW2ShTa7k#:h=As-an-author
+-->
+
+#### Summary
+<!-- Simple summary of what the code does or what you have changed. -->
+
+
+#### Motivation
+<!-- Why are you making this change? This can be a link to a Jira task. -->
+
+
+#### Test plan
+<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
+
+
+#### Rollout/monitoring/revert plan
+<!-- Instructions for deploying, monitoring, and reverting this change. -->
+
+
+cc @stripe/observability


### PR DESCRIPTION
Observability officially maintains Unilog, but this isn't actually written anywhere, so there's no way anybody would know!


This PR automatically CCs the team on all Unilog pull requests.

r? @stripe/observability