### PR TITLE
Add Go 1.8 release to Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: go
 go:
   - 1.7
+  - 1.8
   - tip


### PR DESCRIPTION
#### Summary

1.8 is now out. So now, we're building against 1.7, 1.8, and tip.

#### Motivation
<!-- Why are you making this change? This can be a link to a Jira task. -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->


r? @stripe/observability
