### PR TITLE
[WIP] Add stats client to filters

### DIFF
--- a/unilog.go
+++ b/unilog.go
@@ -25,7 +25,7 @@ var statstags string
 
 // A filter to be applied to log lines prior to prefixing them
 // with a timestamp and logging them.
-type Filter func(string) string
+type Filter func(string, *statsd.Client) string
 
 // Unilog represents a unilog process. unilog is intended to be used
 // as a standalone application, but is exported as a package to allow
@@ -194,7 +194,7 @@ func (u *Unilog) reopen() error {
 func (u *Unilog) format(line string) string {
 	for _, filter := range u.Filters {
 		if filter != nil {
-			line = filter(line)
+			line = filter(line, Stats)
 		}
 	}
 	return fmt.Sprintf("[%s] %s\n", time.Now().Format("2006-01-02 15:04:05.000000"), line)

--- a/unilog/main.go
+++ b/unilog/main.go
@@ -5,11 +5,12 @@ import (
 	"math"
 	"math/rand"
 
+	"github.com/DataDog/datadog-go/statsd"
 	"github.com/stripe/unilog"
 	"github.com/stripe/unilog/clevels"
 )
 
-func austerityFilter(line string) string {
+func austerityFilter(line string, stats *statsd.Client) string {
 	criticalityLevel := clevels.Criticality(line)
 	austerityLevel := <-clevels.SystemAusterityLevel
 	fmt.Printf("austerity level is %s\n", austerityLevel)

--- a/unilog_test.go
+++ b/unilog_test.go
@@ -1,6 +1,7 @@
 package unilog
 
 import (
+	"github.com/DataDog/datadog-go/statsd"
 	"os"
 	"strings"
 	"syscall"
@@ -58,11 +59,11 @@ func TestFilterFunction(t *testing.T) {
 	u := &Unilog{}
 
 	// double the first two instances of the character "e"
-	var doubleEFilter = func(s string) string {
+	var doubleEFilter = func(s string, stats *statsd.Client) string {
 		return strings.Replace(s, "e", "ee", 2)
 	}
 
-	var isToAintFilter = func(s string) string {
+	var isToAintFilter = func(s string, stats *statsd.Client) string {
 		return strings.Replace(s, "is", "ain't", -1)
 	}
 


### PR DESCRIPTION
#### Summary
This PR adds the Statsd client as a parameter to the filter function, which allows the passed in filters to report metrics about their usage and whatnot. 


#### Motivation
Stats on filters!


#### Test plan
Updated the tests.


#### Rollout/monitoring/revert plan
Puppet the world!

r? @asf-stripe 