### PR TITLE
Test Refactor

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -42,10 +42,6 @@ func (r *UnilogReader) Read(buf []byte) (int, error) {
 		return 0, io.EOF
 	}
 
-	if r.isShuttingDown() {
-		buf = buf[:1]
-	}
-
 	n, e := r.inner.Read(buf)
 	if n > 0 {
 		r.nl = buf[n-1] == '\n'

--- a/reader_test.go
+++ b/reader_test.go
@@ -92,43 +92,40 @@ func (or *OurReader) Read(p []byte) (n int, err error) {
 	return copy(p, bs), nil
 }
 
-func TestReaderAlone(t *testing.T) {
-	t.Run("basic", func(t *testing.T) {
-		input := make(chan []byte, 1)
-		inRdr := OurReader{input}
-		shutdown := make(chan struct{}, 1)
-		close(shutdown)
-		rdr := NewUnilogReader(&inRdr, shutdown)
-		bufRdr := bufio.NewReader(rdr)
-		input <- []byte("hello I am a line\n")
-		line, err := bufRdr.ReadString('\n')
-		if err != nil {
-			t.Error(err)
-		}
-		if line != "hello I am a line\n" {
-			t.Error(line)
-		}
-	})
+func TestReaderBasic(t *testing.T) {
+	input := make(chan []byte, 1)
+	inRdr := OurReader{input}
+	shutdown := make(chan struct{}, 1)
+	close(shutdown)
+	rdr := NewUnilogReader(&inRdr, shutdown)
+	bufRdr := bufio.NewReader(rdr)
+	input <- []byte("hello I am a line\n")
+	line, err := bufRdr.ReadString('\n')
+	if err != nil {
+		t.Error(err)
+	}
+	if line != "hello I am a line\n" {
+		t.Error(line)
+	}
+}
 
-	// Less happy case: shutdown with a missing newline.
-	t.Run("complex", func(t *testing.T) {
-		input := make(chan []byte)
-		inRdr := OurReader{input}
-		shutdown := make(chan struct{})
-		close(shutdown)
-		rdr := NewUnilogReader(&inRdr, shutdown)
-		bufRdr := bufio.NewReader(rdr)
+func TestReaderComplex(t *testing.T) {
+	input := make(chan []byte)
+	inRdr := OurReader{input}
+	shutdown := make(chan struct{})
+	close(shutdown)
+	rdr := NewUnilogReader(&inRdr, shutdown)
+	bufRdr := bufio.NewReader(rdr)
 
-		go func() {
-			input <- []byte("unterminated")
-			input <- []byte("done\n")
-		}()
-		line, err := bufRdr.ReadString('\n')
-		if err != nil {
-			t.Error(err)
-		}
-		if line != "unterminateddone\n" {
-			t.Error(line)
-		}
-	})
+	go func() {
+		input <- []byte("unterminated")
+		input <- []byte("done\n")
+	}()
+	line, err := bufRdr.ReadString('\n')
+	if err != nil {
+		t.Error(err)
+	}
+	if line != "unterminateddone\n" {
+		t.Error(line)
+	}
 }

--- a/unilog.go
+++ b/unilog.go
@@ -77,7 +77,8 @@ type Unilog struct {
 		count  int
 	}
 
-	exit func(int)
+	exit           func(int)
+	shouldShutdown bool
 }
 
 func stringFlag(val *string, longname, shortname, init, help string) {
@@ -224,31 +225,36 @@ func (u *Unilog) logLine(line string) {
 
 func (u *Unilog) run() {
 	for {
-		select {
-		case e := <-u.errs:
-			if e != nil && e != io.EOF {
-				panic(e)
-			} else {
-				return
-			}
-		case <-u.sigReopen:
-			u.reopen()
-		case <-u.sigTerm:
-			if u.shutdown != nil {
-				close(u.shutdown)
-				u.shutdown = nil
-			}
-		case <-u.sigQuit:
-			if u.shutdown == nil {
-				u.exit(1)
-				return
-			}
-		case line, ok := <-u.lines:
-			if !ok {
-				return
-			}
-			u.logLine(line)
+		u.selector()
+	}
+}
+
+func (u *Unilog) selector() {
+	select {
+	case e := <-u.errs:
+		if e != nil && e != io.EOF {
+			panic(e)
+		} else {
+			return
 		}
+	case <-u.sigReopen:
+		u.reopen()
+	case <-u.sigTerm:
+		select {
+		case u.shutdown <- struct{}{}:
+			u.shouldShutdown = true
+		default:
+		}
+	case <-u.sigQuit:
+		if u.shouldShutdown {
+			u.exit(1)
+			return
+		}
+	case line, ok := <-u.lines:
+		if !ok {
+			return
+		}
+		u.logLine(line)
 	}
 }
 

--- a/unilog_test.go
+++ b/unilog_test.go
@@ -106,7 +106,6 @@ func TestTwoStateExit(t *testing.T) {
 
 	term <- syscall.SIGTERM
 	<-u.shutdown
-
 	quit <- syscall.SIGQUIT
 
 	<-exit
@@ -116,11 +115,10 @@ func TestTwoStateExit(t *testing.T) {
 }
 
 func TestSigTermNoExit(t *testing.T) {
-	r := strings.NewReader(strings.Join(shakespeare, "\n"))
 	u := &Unilog{}
 
-	term := make(chan os.Signal, 2)
-	quit := make(chan os.Signal, 2)
+	term := make(chan os.Signal, 1)
+	quit := make(chan os.Signal, 1)
 
 	u.sigTerm = term
 	u.sigQuit = quit
@@ -129,18 +127,15 @@ func TestSigTermNoExit(t *testing.T) {
 	}
 	u.shutdown = make(chan struct{})
 
-	go u.run()
-
 	term <- syscall.SIGTERM
-	u.lines, u.errs = readlines(r, u.BufferLines, u.shutdown)
+	u.selector()
 }
 
 func TestSigQuitNoOp(t *testing.T) {
-	r := strings.NewReader(strings.Join(shakespeare, "\n"))
 	u := &Unilog{}
 
-	term := make(chan os.Signal, 2)
-	quit := make(chan os.Signal, 2)
+	term := make(chan os.Signal, 1)
+	quit := make(chan os.Signal, 1)
 
 	u.sigTerm = term
 	u.sigQuit = quit
@@ -149,8 +144,6 @@ func TestSigQuitNoOp(t *testing.T) {
 	}
 	u.shutdown = make(chan struct{})
 
-	go u.run()
-
 	quit <- syscall.SIGQUIT
-	u.lines, u.errs = readlines(r, u.BufferLines, u.shutdown)
+	u.selector()
 }

--- a/unilog_test.go
+++ b/unilog_test.go
@@ -87,7 +87,6 @@ func TestFilterFunction(t *testing.T) {
 }
 
 func TestTwoStateExit(t *testing.T) {
-	r := strings.NewReader(strings.Join(shakespeare, "\n"))
 	u := &Unilog{}
 	exitCode := -1
 
@@ -106,8 +105,8 @@ func TestTwoStateExit(t *testing.T) {
 	go u.run()
 
 	term <- syscall.SIGTERM
-	u.lines, u.errs = readlines(r, u.BufferLines, u.shutdown)
 	<-u.shutdown
+
 	quit <- syscall.SIGQUIT
 
 	<-exit
@@ -130,10 +129,10 @@ func TestSigTermNoExit(t *testing.T) {
 	}
 	u.shutdown = make(chan struct{})
 
+	go u.run()
+
 	term <- syscall.SIGTERM
 	u.lines, u.errs = readlines(r, u.BufferLines, u.shutdown)
-
-	go u.run()
 }
 
 func TestSigQuitNoOp(t *testing.T) {
@@ -150,7 +149,8 @@ func TestSigQuitNoOp(t *testing.T) {
 	}
 	u.shutdown = make(chan struct{})
 
+	go u.run()
+
 	quit <- syscall.SIGQUIT
 	u.lines, u.errs = readlines(r, u.BufferLines, u.shutdown)
-	go u.run()
 }

--- a/unilog_test.go
+++ b/unilog_test.go
@@ -128,7 +128,9 @@ func TestSigTermNoExit(t *testing.T) {
 	u.shutdown = make(chan struct{})
 
 	term <- syscall.SIGTERM
-	u.selector()
+	if !u.tick() {
+		t.Error("Tick returned false.")
+	}
 }
 
 func TestSigQuitNoOp(t *testing.T) {
@@ -145,5 +147,7 @@ func TestSigQuitNoOp(t *testing.T) {
 	u.shutdown = make(chan struct{})
 
 	quit <- syscall.SIGQUIT
-	u.selector()
+	if !u.tick() {
+		t.Error("Tick returned false.")
+	}
 }


### PR DESCRIPTION
#### Summary
Tests don't pass consistently due to race conditions, and this PR aims to fix those.

This PR:
- Refactors Unilog's `run` method to have a `tick`, so that we can test that it behaves correctly upon receiving different signals.
- Refactors Unilog's tests to remove race conditions.
- Refactors Reader to remove the race condition with the `shuttingDown` boolean by adding a mutex.
- Removes old (and probably broken) Reader code.
- Adds new Reader tests in `reader_test.go` and deprecates the old one.

TL;DR: running `go test -race` now passes!


#### Motivation
Currently, the tests in master don't pass consistently, which makes opening new PR's to Unilog difficult, since the existing tests may or may not (more common) pass.


#### Test plan
`go test` locally.


#### Rollout/monitoring/revert plan
Puppet the world


r? @asf-stripe 
cc @stripe/observability