### PR TITLE
Linter changes

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -41,13 +41,13 @@ func testUnilogReader(t *testing.T) {
 	}
 	for i, tc := range tests {
 		shutdown := make(chan struct{})
-		rd := NewUnilogReader(strings.NewReader(tc.in), shutdown)
+		rd := NewReader(strings.NewReader(tc.in), shutdown)
 		buf := make([]byte, 128)
 		for _, o := range tc.ops {
 			if o.read < 0 {
 				close(shutdown)
 				// HACK: Wait for the shutdown to propagate.
-				for !rd.(*UnilogReader).shuttingDown {
+				for !rd.(*Reader).shuttingDown {
 					time.Sleep(1 * time.Millisecond)
 				}
 				continue
@@ -97,7 +97,7 @@ func TestReaderBasic(t *testing.T) {
 	inRdr := OurReader{input}
 	shutdown := make(chan struct{}, 1)
 	close(shutdown)
-	rdr := NewUnilogReader(&inRdr, shutdown)
+	rdr := NewReader(&inRdr, shutdown)
 	bufRdr := bufio.NewReader(rdr)
 	input <- []byte("hello I am a line\n")
 	line, err := bufRdr.ReadString('\n')
@@ -114,7 +114,7 @@ func TestReaderComplex(t *testing.T) {
 	inRdr := OurReader{input}
 	shutdown := make(chan struct{})
 	close(shutdown)
-	rdr := NewUnilogReader(&inRdr, shutdown)
+	rdr := NewReader(&inRdr, shutdown)
 	bufRdr := bufio.NewReader(rdr)
 
 	go func() {

--- a/unilog.go
+++ b/unilog.go
@@ -23,8 +23,9 @@ import (
 // hold the argument passed in with "-statstags"
 var statstags string
 
-// A filter to be applied to log lines prior to prefixing them
-// with a timestamp and logging them.
+// A Filter is a function that takes in a log line and applies
+// a transformation prior to prefixing them with a
+// timestamp and logging them.
 type Filter func(string) string
 
 // Unilog represents a unilog process. unilog is intended to be used
@@ -140,13 +141,14 @@ const (
 	DefaultBuffer = 1 << 12
 )
 
+// Stats is Unilog's statsd client.
 var Stats *statsd.Client
 
 func readlines(in io.Reader, bufsize int, shutdown chan struct{}) (<-chan string, <-chan error) {
 	linec := make(chan string, bufsize)
 	errc := make(chan error, 1)
 
-	u := NewUnilogReader(in, shutdown)
+	u := NewReader(in, shutdown)
 	r := bufio.NewReader(u)
 
 	go func() {
@@ -317,6 +319,7 @@ func (u *Unilog) handleError(action string, e error) {
 	u.b.count++
 }
 
+// Main sets up the Unilog instance and then calls Run.
 func (u *Unilog) Main() {
 	u.fillDefaults()
 


### PR DESCRIPTION
#### Summary
- Rename `unilog.UnilogReader` to `unilog.Reader` 
- Adds comments to exported functions lacking comments


#### Motivation
Linter had some suggested changes!


#### Test plan
Tests still pass.


#### Rollout/monitoring/revert plan
Puppet!

r? @asf-stripe 