### PR TITLE
Add Go 1.9 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: go
 go:
   - 1.7
   - 1.8
+  - 1.9
   - tip


### PR DESCRIPTION
#### Summary


Add Go 1.9 to the build matrix. We were testing 1.7, 1.8, and tip (the soon-to-be 1.10), but not 1.9.


#### Motivation
<!-- Why are you making this change? -->


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

r? @stripe/observability 