### PR TITLE
Handle JSON inputs

### DIFF
--- a/filters/austerity_test.go
+++ b/filters/austerity_test.go
@@ -8,12 +8,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stripe/unilog/clevels"
+	"github.com/stripe/unilog/json"
 )
 
 func TestAusterityFilter(t *testing.T) {
 	// Make sure SendSystemAusterityLevel is called before we override
 	// the underlying channel below
-	AusterityFilter("")
+	a := AusterityFilter{}
+	a.Setup(true)
 
 	clevels.SystemAusterityLevel = make(chan clevels.AusterityLevel)
 
@@ -40,7 +42,7 @@ func TestAusterityFilter(t *testing.T) {
 
 	// now sample out the line a bunch!
 	for i := 0; i < 10000; i++ {
-		outputtedLine = AusterityFilter(line)
+		outputtedLine = a.FilterLine(line)
 		if strings.Contains(outputtedLine, "(shedded)") {
 			dropped++
 		}
@@ -48,6 +50,44 @@ func TestAusterityFilter(t *testing.T) {
 
 	// this number is deterministic because rand is seeded & deterministic
 	// TODO (kiran, 2016-12-06): maybe add an epsilon
+	assert.Equal(t, 8983, dropped)
+	kill <- struct{}{}
+}
+
+func TestAusterityJSON(t *testing.T) {
+	// Make sure SendSystemAusterityLevel is called before we override
+	// the underlying channel below
+	a := AusterityFilter{}
+	a.Setup(true)
+	clevels.SystemAusterityLevel = make(chan clevels.AusterityLevel)
+	kill := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case clevels.SystemAusterityLevel <- clevels.Critical:
+			case <-kill:
+				return
+			}
+		}
+	}()
+
+	// seed rand deterministically
+	rand.Seed(17)
+
+	// count number of lines dropped
+	dropped := 0
+
+	// now sample out the line a bunch!
+	for i := 0; i < 10000; i++ {
+		line := json.LogLine{"message": "some random log line!", "clevel": "sheddableplus"}
+		a.FilterJSON(&line)
+		if _, ok := line["message"]; !ok {
+			dropped++
+		}
+	}
+
+	// this number is deterministic because rand is seeded & deterministic
 	assert.Equal(t, 8983, dropped)
 	kill <- struct{}{}
 }

--- a/json/json.go
+++ b/json/json.go
@@ -42,11 +42,13 @@ var tsFields = []string{
 	"ts",
 }
 
-// TS returns the timestamp of a log line; if a timestamp is set, TS
-// will attempt to parse it (first according to time.RFC3339Nano and
-// then time.RFC1123Z); if no timestamp is present, or the present
-// time stamp can not be parsed, TS returns the current time.
-func (j *LogLine) TS() time.Time {
+// Timestamp returns the timestamp of a log line; if a timestamp is
+// set on the line, Timestamp will attempt to interpret it
+// (integers/floats as UNIX epochs with fractional sub-second
+// components, and strings first according to time.RFC3339Nano and
+// then time.RFC1123Z). If no timestamp is present, or the present
+// time stamp can not be parsed, Timestamp returns the current time.
+func (j *LogLine) Timestamp() time.Time {
 	for _, tsField := range tsFields {
 		if tsS, ok := (*j)[tsField]; ok {
 			// We support two different kinds of
@@ -89,7 +91,7 @@ func (j LogLine) MarshalJSON() ([]byte, error) {
 	b := bytes.NewBuffer(encodePrefix)
 	b.Grow(len(j) * 15) // very naive assumption: average key/value pair is 15 bytes long.
 
-	nsepoch := j.TS().UnixNano()
+	nsepoch := j.Timestamp().UnixNano()
 	sec := time.Duration(nsepoch) / time.Second
 	usec := (time.Duration(nsepoch) - (sec * time.Second)) / time.Nanosecond
 	fmt.Fprintf(b, "%d.%09d", sec, usec)

--- a/json/json.go
+++ b/json/json.go
@@ -23,7 +23,7 @@ package json
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	"fmt"
 	"time"
 )
 
@@ -71,15 +71,12 @@ func (j LogLine) MarshalJSON() ([]byte, error) {
 			continue
 		}
 		b.WriteString(",")
-		kJSON, err := json.Marshal(k)
-		if err != nil {
-			log.Fatal("TODO: what(k)", k, err)
-		}
-		b.Write(kJSON)
+		kJSON, _ := json.Marshal(k)
 		vJSON, err := json.Marshal(v)
 		if err != nil {
-			log.Fatal("TODO: what(v)", v, err)
+			vJSON, _ = json.Marshal(fmt.Sprintf(`[unilog json marshal error: %v]`, err))
 		}
+		b.Write(kJSON)
 		b.WriteString(":")
 		b.Write(vJSON)
 	}

--- a/json/json.go
+++ b/json/json.go
@@ -1,0 +1,88 @@
+// Package json provides a type and helpers for representing JSON log
+// lines.
+//
+// Format
+//
+// The JSON log line format consists of JSON objects, one per
+// \n-terminated line.
+//
+// Unilog recognizes three fields in that object that are considered
+// special (all are optional):
+//
+//    - ts: The time stamp of an event
+//    - canonical: Identifies the log event as "canonical", i.e. the
+//      most important line a service can log. It is considered to have
+//      the highest criticality level.
+//    - clevel: The criticality level of the event.
+//
+// Example
+//
+//    {"ts":"2006-01-02T15:04:05.999Z07:00","message":"hi there"}
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"time"
+)
+
+// JSONLogLine is a representation of a generic log line that unilog
+// can destructure.
+type LogLine map[string]interface{}
+
+const defaultTimeFormat = time.RFC3339Nano
+
+// TS returns the timestamp of a log line; if a timestamp is set, TS
+// will attempt to parse it (first according to time.RFC3339Nano and
+// then time.RFC1123Z); if no timestamp is present, or the present
+// time stamp can not be parsed, TS returns the current time.
+func (j *LogLine) TS() time.Time {
+	if tsS, ok := (*j)["ts"]; ok {
+		tsS, ok := tsS.(string)
+		if !ok {
+			return time.Now()
+		}
+		// We have a ts, let's try and parse it:
+		ts, err := time.Parse(time.RFC3339Nano, tsS)
+		if err == nil {
+			return ts
+		}
+		ts, err = time.Parse(time.RFC1123Z, tsS)
+		if err == nil {
+			return ts
+		}
+	}
+	return time.Now()
+}
+
+// MarshalJSON writes the log line in a specific format that's
+// optimized for splunk ingestion: First, it writes the timestamp,
+// followed by all the other fields.
+func (j LogLine) MarshalJSON() ([]byte, error) {
+	b := bytes.NewBuffer(([]byte)("{"))
+	b.Grow(len(j) * 15) // very naive assumption: average key/value pair is 15 bytes long.
+	b.WriteString(`"ts":"`)
+	ts := j.TS().Format(defaultTimeFormat)
+	b.WriteString(ts)
+	b.WriteString(`"`)
+	for k, v := range j {
+		if k == "ts" {
+			continue
+		}
+		b.WriteString(",")
+		kJSON, err := json.Marshal(k)
+		if err != nil {
+			log.Fatal("TODO: what(k)", k, err)
+		}
+		b.Write(kJSON)
+		vJSON, err := json.Marshal(v)
+		if err != nil {
+			log.Fatal("TODO: what(v)", v, err)
+		}
+		b.WriteString(":")
+		b.Write(vJSON)
+	}
+	b.WriteString("}")
+	return b.Bytes(), nil
+}

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1,0 +1,76 @@
+package json
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTS(t *testing.T) {
+	tests := []struct {
+		inputTS  string
+		now      bool
+		outputTS string
+	}{
+		{"2006-01-02T15:04:05.999999999Z", false, "2006-01-02T15:04:05.999999999Z"},
+		{"2006-01-02T15:04:05Z", false, "2006-01-02T15:04:05Z"},
+		{"Mon, 02 Jan 2006 15:04:05 -0700", false, "2006-01-02T15:04:05Z"},
+		{"gibberish", true, ""},
+	}
+	nowish := time.Now()
+	layout := "2006-01-02T15:04:05.999999999Z"
+	for _, elt := range tests {
+		test := elt
+		name := fmt.Sprintf("%s", elt.inputTS)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			line := LogLine{"ts": test.inputTS}
+			ts := line.TS()
+			if !test.now {
+				assert.False(t, nowish.Before(ts),
+					"timestamp %v should be an actual timestamp, not time.Now()",
+					nowish,
+				)
+				out := ts.Format(layout)
+				assert.Equal(t, test.outputTS, out)
+			} else {
+				assert.True(t, nowish.Before(ts),
+					"timestamp %v should be sometime after the start of the test %v",
+					nowish, ts)
+			}
+		})
+	}
+}
+
+func TestMarshal(t *testing.T) {
+	tests := []struct {
+		in string
+	}{
+		{`{"msg":"hi", "ts":"2006-01-02T15:04:05.999999999Z"}`},
+		{`{"msg":"hi"}`},
+		{`{"what":"no",    "teletubbies":["boo", "lala"]}`},
+	}
+	for _, elt := range tests {
+		test := elt
+		t.Run(test.in, func(t *testing.T) {
+			t.Parallel()
+			var line LogLine
+			err := json.Unmarshal(([]byte)(test.in), &line)
+			require.NoError(t, err)
+
+			out, err := json.Marshal(line)
+			outstr := (string)(out)
+			require.NoError(t, err)
+			assert.True(t, strings.HasPrefix(outstr, `{"ts":"`), outstr)
+
+			var roundtrip LogLine
+			err = json.Unmarshal(out, &roundtrip)
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -31,7 +31,7 @@ func TestTS(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			line := LogLine{"timestamp": test.inputTS}
-			ts := line.TS()
+			ts := line.Timestamp()
 			if !test.now {
 				assert.False(t, nowish.Before(ts),
 					"timestamp %v should be an actual timestamp, not time.Now()",
@@ -49,7 +49,7 @@ func TestTS(t *testing.T) {
 				require.NoError(t, err)
 
 				t.Logf("log line: %s", string(b))
-				assert.WithinDuration(t, epoch, roundtrip.TS(), time.Microsecond)
+				assert.WithinDuration(t, epoch, roundtrip.Timestamp(), time.Microsecond)
 			} else {
 				assert.True(t, nowish.Before(ts),
 					"timestamp %v should be sometime after the start of the test %v",

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 func main() {
 	u := &logger.Unilog{
 		Filters: []logger.Filter{
-			logger.Filter(filters.AusterityFilter),
+			logger.Filter(filters.AusterityFilter{}),
 		},
 	}
 	u.Main()


### PR DESCRIPTION
#### Summary
This PR makes unilog handle JSON log inputs from stdin, with these assumptions:

* Each log event is a JSON object
* log events are separated by \n (much like json.Encoder formats them)
* timestamp fields are called "ts"
* criticality level fields are called "clevel"

This happens to be pretty compatible with Splunk, AFAICT.

This is an **incompatible** change, as it alters the Filter interface.

#### Motivation

I would like our JSON log-emission story to be much better, and this
might be a good first stepping stone towards that world; in particular:

* JSON logs render nicely in most tools
* Splunk is much much better at parsing JSON logs than at splitting up
  fields via regexes, apparently.

#### Test plan

I wrote some automated tests, but I guess we'll have to run it and see.

#### Rollout/monitoring/revert plan

Merge this, integrate it into our unilog-using log ingester and then
roll that out.