### PR TITLE
Remove automatic file_name tag and bump version

### DIFF
--- a/logger/unilog.go
+++ b/logger/unilog.go
@@ -144,7 +144,7 @@ const (
 	// Version is the Unilog version. Reported in emails and in
 	// response to --version on the command line. Can be overriden
 	// by the Version field in a Unilog object.
-	Version = "0.3"
+	Version = "0.4"
 	// DefaultBuffer is the default size (in lines) of the
 	// in-process line buffer
 	DefaultBuffer = 1 << 12
@@ -459,7 +459,6 @@ func (u *Unilog) Main() {
 	tagState = setupIndependentTags()
 
 	Stats = setupStatsd(u.StatsdAddress, fileName, statstags)
-	Stats.Tags = append(Stats.Tags, fmt.Sprintf("file_name:%s", fileName))
 
 	clevels.Stats = setupStatsd(u.StatsdAddress, fileName, cleveltags)
 


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->
Removes the file_name tag that is added to every metric automatically without being able to configure it.

This is a breaking change, to recover the old behavior simply add the tag to --statsdtags directly.

#### Motivation
<!-- Why are you making this change? -->
Allow for fine-grain control over exactly which tags appear on emitted metrics.

#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->
Test in qa

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
Revert this commit