### PR TITLE
Separate timestamp insertion into a filter

### DIFF
--- a/filters/timeprefix.go
+++ b/filters/timeprefix.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stripe/unilog/json"
+	flag "launchpad.net/gnuflag"
 )
 
 const defaultFormat = "2006-01-02 15:04:05.000000"
@@ -12,22 +13,30 @@ const defaultFormat = "2006-01-02 15:04:05.000000"
 // TimePrefixFilter prepends a timestamp onto each event line using the specified
 // format string, plus an optional newline.
 type TimePrefixFilter struct {
+	Omit   bool
 	Format string
 }
 
 // FilterLine prepends the current time, in square brackets with a separating
 // space, to the provided log line.
-func (f TimePrefixFilter) FilterLine(line string) string {
+func (f *TimePrefixFilter) FilterLine(line string) string {
+	if f.Omit {
+		return line
+	}
 	return fmt.Sprintf("[%s] %s", time.Now().Format(f.getTimeFormat()), line)
 }
 
 // FilterJSON is a no-op - TimePrefixFilter does nothing on JSON logs (for now!).
-func (f TimePrefixFilter) FilterJSON(line *json.LogLine) {}
+func (f *TimePrefixFilter) FilterJSON(line *json.LogLine) {}
 
-func (f TimePrefixFilter) getTimeFormat() string {
+func (f *TimePrefixFilter) getTimeFormat() string {
 	if f.Format != "" {
 		return f.Format
 	}
 
 	return defaultFormat
+}
+
+func (f *TimePrefixFilter) AddFlags() {
+	flag.BoolVar(&f.Omit, "omit-timestamps", false, "Do not prepend timestamps to each line before flushing.")
 }

--- a/filters/timeprefix.go
+++ b/filters/timeprefix.go
@@ -1,0 +1,33 @@
+package filters
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/stripe/unilog/json"
+)
+
+const defaultFormat = "2006-01-02 15:04:05.000000"
+
+// TimePrefixFilter prepends a timestamp onto each event line using the specified
+// format string, plus an optional newline.
+type TimePrefixFilter struct {
+	Format string
+}
+
+// FilterLine prepends the current time, in square brackets with a separating
+// space, to the provided log line.
+func (f TimePrefixFilter) FilterLine(line string) string {
+	return fmt.Sprintf("[%s] %s", time.Now().Format(f.getTimeFormat()), line)
+}
+
+// FilterJSON is a no-op - TimePrefixFilter does nothing on JSON logs (for now!).
+func (f TimePrefixFilter) FilterJSON(line *json.LogLine) {}
+
+func (f TimePrefixFilter) getTimeFormat() string {
+	if f.Format != "" {
+		return f.Format
+	}
+
+	return defaultFormat
+}

--- a/filters/timeprefix_test.go
+++ b/filters/timeprefix_test.go
@@ -1,0 +1,50 @@
+package filters
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stripe/unilog/json"
+)
+
+var low time.Time = time.Now()
+
+func TestTimePrefixLine(t *testing.T) {
+	f := TimePrefixFilter{}
+	str := f.FilterLine("")
+	f.Format = time.UnixDate
+	str2 := f.FilterLine("")
+
+	between(t, str[1:27], defaultFormat, low, time.Now())
+	between(t, str2[1:29], time.UnixDate, low, time.Now())
+}
+
+func TestTimePrefixJSON(t *testing.T) {
+	f := TimePrefixFilter{}
+	m := json.LogLine(map[string]interface{}{})
+	f.FilterJSON(&m)
+
+	assert.Equal(t, len(m), 0, "JSON filter should make no map modifications")
+}
+
+func between(t *testing.T, check string, format string, bottom, high time.Time) {
+	t.Helper()
+	c, err := time.Parse(format, check)
+
+	if err != nil {
+		t.Fatal(fmt.Sprintf("Input string was not a parseable timestamp: %s", check))
+	}
+
+	// Converting the timestamps to strings and back - as inherently happens
+	// when the filter prints them in the log - seems to introduce a stable
+	// inaccuracy specific to the format. So, convert our low and high bounds to
+	// and back from strings, then check bounds based on that.
+	lstr, hstr := bottom.Format(format), high.Format(format)
+	plow, _ := time.Parse(format, lstr)
+	phigh, _ := time.Parse(format, hstr)
+
+	assert.True(t, (c.After(plow) || c.Equal(plow)), "Input (%q) was below lower bound (%q) by %dns", check, plow.Format(format), plow.Sub(c))
+	assert.True(t, (phigh.After(c) || c.Equal(phigh)), "Input (%q) was above upper bound (%q) by %dns", check, phigh.Format(format), c.Sub(phigh))
+}

--- a/filters/timeprefix_test.go
+++ b/filters/timeprefix_test.go
@@ -30,7 +30,12 @@ func TestTimePrefixJSON(t *testing.T) {
 }
 
 func between(t *testing.T, check string, format string, bottom, high time.Time) {
-	t.Helper()
+	if h, ok := interface{}(t).(interface {
+		Helper()
+	}); ok {
+		h.Helper()
+	}
+
 	c, err := time.Parse(format, check)
 
 	if err != nil {

--- a/filters/timeprefix_test.go
+++ b/filters/timeprefix_test.go
@@ -19,6 +19,9 @@ func TestTimePrefixLine(t *testing.T) {
 
 	between(t, str[1:27], defaultFormat, low, time.Now())
 	between(t, str2[1:29], time.UnixDate, low, time.Now())
+
+	f.Omit = true
+	assert.Equal(t, "", f.FilterLine(""), "Empty input should have empty output when f.Omit == true, got %q", f.FilterLine(""))
 }
 
 func TestTimePrefixJSON(t *testing.T) {

--- a/logger/unilog.go
+++ b/logger/unilog.go
@@ -33,11 +33,10 @@ var cleveltags string
 // hold the argument passed with "-independenttags"
 var independenttags string
 
-// Filter takes in a log line and applies a transformation prior to
-// prefixing them with a timestamp and logging them. Since Unilog can
-// operate on JSON or on string content, there are two methods that a
-// filter must implement (so unilog can cut down on time spent parsing
-// the log line).
+// Filter takes in a log line and applies a transformation prior to logging
+// them. Since Unilog can operate on JSON or on string content, there are two
+// methods that a filter must implement (so unilog can cut down on time spent
+// parsing the log line).
 type Filter interface {
 	FilterLine(line string) string
 	FilterJSON(line *json.LogLine)
@@ -301,7 +300,7 @@ func (u *Unilog) format(line string) string {
 			line = filter.FilterLine(line)
 		}
 	}
-	return fmt.Sprintf("[%s] %s\n", time.Now().Format("2006-01-02 15:04:05.000000"), line)
+	return line + "\n"
 }
 
 func (u *Unilog) logLine(line string) {

--- a/logger/unilog_test.go
+++ b/logger/unilog_test.go
@@ -89,15 +89,6 @@ func TestFilterFunction(t *testing.T) {
 	}
 
 	result := u.format(input)
-
-	i := strings.Index(result, "]")
-	if i == -1 {
-		t.Errorf("Expected timestamp but found none")
-	}
-
-	// Remove the entire timestamp and the leading space to avoid
-	// having to match the timestamp part of the string in the test
-	result = result[i+2:]
 	if result != expected {
 		t.Errorf("expected %q, found %q", expected, result)
 	}

--- a/main.go
+++ b/main.go
@@ -6,9 +6,14 @@ import (
 )
 
 func main() {
+	tf := &filters.TimePrefixFilter{}
+	// Register flags so they're picked up when u.Main() calls flag.Parse() (ugh)
+	tf.AddFlags()
+
 	u := &logger.Unilog{
 		Filters: []logger.Filter{
 			logger.Filter(filters.AusterityFilter{}),
+			logger.Filter(tf),
 		},
 	}
 	u.Main()


### PR DESCRIPTION
Separate timestamp insertion into a filter


#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

Currently, timestamp injection is hardcoded as part of line processing. If you need something to come before the timestamp in emitted lines, that's a problem.

This makes timestamp injection into just another filter, granting full control. Now, the only hardcoded bit that's added is a newline, and that's just replacing what the tokenizer already stripped out.

This changes the default behavior to NOT have a timestamp. We could inject this filter as a default...maybe? But i don't really see how to do that in a way that isn't an awkward API. Probably better just to bite the bullet.

r? @krisreeves-stripe 
cc @antifuchs @asf-stripe 

#### Motivation
<!-- Why are you making this change? -->

Stripe needs to inject some data before the timestamp.


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

Added new tests.


#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->

Nothing special to do.
