### PR TITLE
Expose functions to set the build info

### DIFF
--- a/logger/unilog.go
+++ b/logger/unilog.go
@@ -167,6 +167,16 @@ var (
 	commitDate = ""
 )
 
+// SetCommitHash sets the commitHash contents, so dependents can inject build info
+func SetCommitHash(hash string) {
+	commitHash = hash
+}
+
+// SetCommitDate sets the commitDate contents, so dependents can inject build info
+func SetCommitDate(date time.Time) {
+	commitDate = date.Format("2006-01-02T15:04:05Z")
+}
+
 // Stats is Unilog's statsd client.
 var Stats *statsd.Client
 


### PR DESCRIPTION
#### Summary / Motivation
The `-ldflags` approach works for this build, but programs that consume Unilog as a dependency may need other ways to specify this info. Expose functions to set the values to support those cases.


#### Test plan
Built a dependent package that called the functions, verified with `unilog -V`


#### Rollout/monitoring/revert plan
Merge, tag a new version
