### PR TITLE
Make GetTags thread safe

### DIFF
--- a/logger/unilog.go
+++ b/logger/unilog.go
@@ -156,7 +156,7 @@ const (
 	// Version is the Unilog version. Reported in emails and in
 	// response to --version on the command line. Can be overriden
 	// by the Version field in a Unilog object.
-	Version = "1.0.1"
+	Version = "1.0.2"
 	// DefaultBuffer is the default size (in lines) of the
 	// in-process line buffer
 	DefaultBuffer = 1 << 12

--- a/logger/unilog.go
+++ b/logger/unilog.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 	"text/template"
 	"time"
@@ -189,6 +190,7 @@ type tagPair struct {
 // independentTags stores a list of tags to individually emit metrics on.
 // Each metric name will be formatted exactly once and cached in metricsTable.
 type independentTags struct {
+	sync.RWMutex
 	// The tags to build metric names from
 	// Format is foo:bar where foo is the tag name
 	Tags []string
@@ -208,6 +210,8 @@ func (it *independentTags) GetTags(metricName string) []tagPair {
 	if it == nil {
 		return []tagPair{}
 	}
+	it.Lock()
+	defer it.Unlock()
 	tags, ok := it.metricsTable[metricName]
 	if ok {
 		return tags

--- a/logger/unilog_test.go
+++ b/logger/unilog_test.go
@@ -234,6 +234,15 @@ func TestWithIndependentTags(t *testing.T) {
 	tagState = tmp
 }
 
+func TestIndependentTagRace(t *testing.T) {
+	tagState = newIndependentTags([]string{"foo:bar"})
+	for i := 0; i < 100; i++ {
+		go func(num int) {
+			tagState.GetTags(fmt.Sprintf("%d", num))
+		}(i)
+	}
+}
+
 func TestSentryPanic(t *testing.T) {
 	defer func() {
 		r := recover()


### PR DESCRIPTION
#### Summary
The "independent tags" instrumentation memoizes its data into a struct, but that struct is being called from multiple goroutines and occasionally racing, causing a "concurrent map writes" crash. This PR adds an RWMutex lock/unlock to the GetTags() call to prevent that.

I considered using sync.Map, but it [doesn't seem to offer any benefit](https://medium.com/@deckarep/the-new-kid-in-town-gos-sync-map-de24a6bf7c2c) for our usage pattern, since we aren't highly parallelized. The extra type assertion introduces more change and slightly more complexity into the logic, so I went with this simpler approach.

#### Motivation
Improve stability


#### Test plan
I added a unit test that tests this specific case which failed reliably before the fix and succeeds after it. TBD: whether we can set up a more comprehensive end-to-end type test that would fail the race detector for other similar errors.


#### Rollout/monitoring/revert plan
Merge, tag, update internal Unilog dependency, deploy that

r? @ChimeraCoder 
