### PR TITLE
Fix daemontools typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## unilog -- a logger process for daemontols [![Build Status](https://travis-ci.org/stripe/unilog.svg?branch=master)](https://travis-ci.org/stripe/unilog)
+## unilog -- a logger process for daemontools [![Build Status](https://travis-ci.org/stripe/unilog.svg?branch=master)](https://travis-ci.org/stripe/unilog)
 
 unilog is a tool for use with djb's [daemontools][daemontools]
 process-monitor.


### PR DESCRIPTION
#### Summary
<!-- Simple summary of what the code does or what you have changed. -->

"daemontols" -> "daemontools"

#### Motivation
<!-- Why are you making this change? -->

I found a typo in the README


#### Test plan
<!-- How did you test this change? This can be as simple as “I wrote automated tests.” -->

n/a just editing a README

#### Rollout/monitoring/revert plan
<!-- Instructions for deploying, monitoring, and reverting this change. -->
s: none

Safe to revert